### PR TITLE
Fix typescript error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
     - name: Install vips
-      run: sudo apt install -y libvips-dev
+      run: sudo apt update && sudo apt install -y libvips-dev
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Install vips
-        run: sudo apt install -y libvips-dev
+        run: sudo apt update && sudo apt install -y libvips-dev
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:

--- a/frontend/src/components/sceneCard/SceneCard.tsx
+++ b/frontend/src/components/sceneCard/SceneCard.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { Card } from "react-bootstrap";
 import { faVideo } from "@fortawesome/free-solid-svg-icons";
 
-import { Scene, Studio } from "src/graphql";
+import { Scene, PerformerFragment, Studio } from "src/graphql";
 import {
   getImage,
   sceneHref,
@@ -20,14 +20,14 @@ import {
 
 type Performance = Pick<
   Scene,
-  | "id"
-  | "title"
-  | "images"
-  | "duration"
-  | "code"
-  | "release_date"
-  | "performers"
+  "id" | "title" | "images" | "duration" | "code" | "release_date"
 > & {
+  performers: {
+    performer: Pick<
+      PerformerFragment,
+      "name" | "disambiguation" | "deleted"
+    > & { id: string };
+  }[];
   studio?: Pick<Studio, "id" | "name"> | null;
 };
 


### PR DESCRIPTION
This fixes failing frontend-lint CI action.

As it happens golangci-lint action has just now also started to fail because of expired ubuntu package, it simply requires running `apt update` in the action ~~but since the issue is in upstream also I didn't include the change in this PR to avoid merge issues if they fix it differently.~~

Edit: realized the old packages also prevents docker hub builds so included the fix after all (obviously feel free to revert the apt update change if they do something different upstream).